### PR TITLE
feat(unquoted-strings): add color for unquoted strings

### DIFF
--- a/themes/bright-night-color-theme.json
+++ b/themes/bright-night-color-theme.json
@@ -151,6 +151,16 @@
       }
     },
     {
+      "name": "String, Unquoted",
+      "scope": [
+        "string",
+        "meta.group.braces.curly constant.other.object.key.js string.unquoted.js"
+      ],
+      "settings": {
+        "foreground": "#FFCB6B"
+      }
+    },
+    {
       "name": "String, Symbols, Inherited Class, Markup Heading",
       "scope": [
         "string",


### PR DESCRIPTION
<img width="570" alt="Screen Shot 2019-10-16 at 7 02 39 PM" src="https://user-images.githubusercontent.com/24883328/66971858-94204d80-f047-11e9-835d-9cabf8621856.png">

resolves: #6 